### PR TITLE
RidersArchiveTool: Fix uncertain file order across all OSes when packing files

### DIFF
--- a/Source/RidersArchiveTool/RidersArchiveTool/Program.cs
+++ b/Source/RidersArchiveTool/RidersArchiveTool/Program.cs
@@ -196,6 +196,7 @@ namespace RidersArchiveTool
                 var groupNo = Convert.ToByte(directoryName[0]);
                 var id      = Convert.ToUInt16(directoryName[1]);
                 var filesInside = Directory.GetFiles(dir);
+                Array.Sort(filesInside); // Ensure files are sorted into the correct order.
 
                 var group = new ManagedGroup() { Id = id, Files = new List<ManagedFile>(filesInside.Length) };
                 foreach (var file in filesInside)


### PR DESCRIPTION
So I ran into an issue while trying to use RidersArchiveTool on Linux (this issue doesn't exist on Windows apparently). When packing files with the `pack` command using the CLI, the way the list of files from the source folders are read in was apparently in some sort of weird order. This is more apparent when trying to pack a PackMan folder that contains a bunch of files.

Looking through the source code, I stumbled upon this quote from the "Remarks" section of the [`Directory.GetFiles()` API](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=net-5.0#system-io-directory-getfiles(system-string)):
> The order of the returned file names is not guaranteed; use the [Sort](https://learn.microsoft.com/en-us/dotnet/api/system.array.sort?view=net-5.0) method if a specific sort order is required.

So in conclusion, all that this PR does is ensure that files are read from the source folders in the correct order, as it is important for PackMan files.

Tested on both Linux and Windows.