### PR TITLE
Added: NativeAOT Builds, Build in CI

### DIFF
--- a/.github/changelog.hbs
+++ b/.github/changelog.hbs
@@ -1,0 +1,23 @@
+# About
+
+A pack containing the following tools:
+- IndexTool: For generating documentation and automatically recognizing file formats.
+- RidersTextureArchiveTool: For extracting textures from XVRS texture archives.
+- RidersArchiveTool: For extracting and repacking Riders archives.
+- LayoutToJson: Can be used to edit animations inside the main menu and even add new menu elements.
+- GcaxDatInjector: Can be used to edit sound effects in `.DAT` files in the GCN version of Riders.
+
+The tools are self-contained native executables (NativeAOT); no .NET runtime installation is required.
+
+## Downloads
+
+- Windows: `windows-x64.zip` / `windows-arm64.zip`
+- Linux: `linux-x64.zip` / `linux-arm64.zip`
+- macOS: `macos-x64.zip` / `macos-arm64.zip`
+
+## What's New
+
+- Tools are now self-contained native executables (NativeAOT, .NET 10).
+- Installing runtimes no longer required.
+- Fixed: Packing archives with RidersArchiveTool produces consistent file order across operating systems. (Thanks
+@Exortile)

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -3,6 +3,8 @@ name: Build Tools (NativeAOT)
 on:
   push:
     branches: [master, build-in-ci]
+    tags:
+      - "*"
   pull_request:
   workflow_dispatch:
 
@@ -56,3 +58,46 @@ jobs:
         with:
           name: ${{ matrix.zip }}
           path: publish/${{ matrix.zip }}
+
+  release:
+    name: GitHub Release
+    # Release only on tags.
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history needed by auto-changelog.
+          fetch-depth: 0
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Setup AutoChangelog
+        run: npm install -g auto-changelog
+
+      - name: Create Changelog
+        run: auto-changelog --sort-commits date --hide-credit --template .github/changelog.hbs --commit-limit false --unreleased --starting-version "${{ github.ref_name }}" --output ./Changelog.md
+
+      - name: Upload Changelog Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Changelog
+          path: Changelog.md
+          retention-days: 0
+
+      - name: Upload to GitHub Releases
+        uses: softprops/action-gh-release@v2
+        with:
+          # Path to load note-worthy description of changes in release from
+          body_path: Changelog.md
+          # Newline-delimited list of path globs for asset files to upload
+          files: |
+            Changelog.md
+            artifacts/**/*.zip

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -2,7 +2,7 @@ name: Build Tools (NativeAOT)
 
 on:
   push:
-    branches: [master, build-in-ci]
+    branches: [master]
     tags:
       - "*"
   pull_request:
@@ -83,7 +83,9 @@ jobs:
         run: npm install -g auto-changelog
 
       - name: Create Changelog
-        run: auto-changelog --sort-commits date --hide-credit --template .github/changelog.hbs --commit-limit false --unreleased --starting-version "${{ github.ref_name }}" --output ./Changelog.md
+        run:
+          auto-changelog --sort-commits date --hide-credit --template .github/changelog.hbs --commit-limit false
+          --unreleased --starting-version "${{ github.ref_name }}" --output ./Changelog.md
 
       - name: Upload Changelog Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -1,0 +1,58 @@
+name: Build Tools (NativeAOT)
+
+on:
+  push:
+    branches: [master, build-in-ci]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: "10.0.x"
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux-x64, os: ubuntu-24.04, rid: linux-x64, zip: linux-x64.zip }
+          - { name: linux-arm64, os: ubuntu-24.04-arm, rid: linux-arm64, zip: linux-arm64.zip }
+          - { name: windows-x64, os: windows-2025, rid: win-x64, zip: windows-x64.zip }
+          - { name: windows-arm64, os: windows-11-arm, rid: win-arm64, zip: windows-arm64.zip }
+          - { name: macos-x64, os: macos-26-intel, rid: osx-x64, zip: macos-x64.zip }
+          - { name: macos-arm64, os: macos-15, rid: osx-arm64, zip: macos-arm64.zip }
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # PublishAot is set per-project in the csproj files; only the RID differs per build.
+      - name: Publish tools
+        run: |
+          dotnet publish Source/RidersArchiveTool/RidersArchiveTool/RidersArchiveTool.csproj -c Release -r ${{ matrix.rid }} -o publish/${{ matrix.rid }}/RidersArchiveTool
+          dotnet publish Source/RidersTextureArchiveTool/RidersTextureArchiveTool/RidersTextureArchiveTool.csproj -c Release -r ${{ matrix.rid }} -o publish/${{ matrix.rid }}/RidersTextureArchiveTool
+          dotnet publish Source/GcaxDatInjector/GcaxDatInjector/GcaxDatInjector.csproj -c Release -r ${{ matrix.rid }} -o publish/${{ matrix.rid }}/GcaxDatInjector
+          dotnet publish Source/IndexTool/IndexTool/IndexTool/IndexTool.csproj -c Release -r ${{ matrix.rid }} -o publish/${{ matrix.rid }}/IndexTool
+          dotnet publish Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/LayoutToJson.csproj -c Release -r ${{ matrix.rid }} -o publish/${{ matrix.rid }}/LayoutToJson
+        env:
+          # Linux NativeAOT links against zlib; runners already provide clang + zlib1g-dev.
+          DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+      - name: Zip
+        run: |
+          cd publish/${{ matrix.rid }}
+          if [ "$RUNNER_OS" = "Windows" ]; then 7z a -tzip ../${{ matrix.zip }} .; else zip -r ../${{ matrix.zip }} .; fi
+          cd ../..
+        shell: bash
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.zip }}
+          path: publish/${{ matrix.zip }}

--- a/Source/GcaxDatInjector/GcaxDatInjector/GcaxDatInjector.csproj
+++ b/Source/GcaxDatInjector/GcaxDatInjector/GcaxDatInjector.csproj
@@ -2,15 +2,26 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- NativeAOT; local-only so it never propagates to submodules. -->
+    <PublishAot>true</PublishAot>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>10.0</LangVersion>
+    <!-- Trim/AOT warnings persist despite rooting; verified needed. -->
+    <NoWarn>$(NoWarn);IL2104;IL3053</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <!-- Keep assemblies; used via reflection. -->
+    <TrimmerRootAssembly Include="GcaxDatInjector" />
+    <TrimmerRootAssembly Include="CommandLine" />
+    <TrimmerRootAssembly Include="RegExtract" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="RegExtract" Version="1.0.18" />
     <PackageReference Include="Reloaded.Memory" Version="4.1.3" />
   </ItemGroup>

--- a/Source/IndexTool/IndexTool/IndexTool/IndexTool.csproj
+++ b/Source/IndexTool/IndexTool/IndexTool/IndexTool.csproj
@@ -2,9 +2,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- NativeAOT; local-only so it never propagates to submodules. -->
+    <PublishAot>true</PublishAot>
+    <!-- JSON reflection serializer; tool serializes runtime types. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <LangVersion>10.0</LangVersion>
+    <!-- Trim/AOT warnings persist despite rooting; verified needed. -->
+    <NoWarn>$(NoWarn);IL2026;IL2062;IL2067;IL2072;IL2075;IL2104;IL3050;IL3053</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Keep assemblies; used via reflection. -->
+    <TrimmerRootAssembly Include="IndexTool" />
+    <TrimmerRootAssembly Include="Mapster" />
+    <TrimmerRootAssembly Include="Sewer56.SonicRiders" />
+    <TrimmerRootAssembly Include="Scriban" />
+    <TrimmerRootAssembly Include="Reloaded.Memory" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Remove="Templates\InternalFileTypes\MarkdownFileTypeTable.txt" />

--- a/Source/IndexTool/IndexTool/IndexTool/Misc/Utilities.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Misc/Utilities.cs
@@ -11,6 +11,7 @@ public static class Utilities
 {
     public static JsonSerializerOptions JsonSerializerOptions { get; private set; } = new JsonSerializerOptions()
     {
+        TypeInfoResolver = Serialization.IndexToolJsonContext.Default,
         WriteIndented = true,
         IncludeFields = true,
         ReadCommentHandling = JsonCommentHandling.Skip

--- a/Source/IndexTool/IndexTool/IndexTool/Options/GenerateFileListing.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Options/GenerateFileListing.cs
@@ -13,7 +13,7 @@ namespace IndexTool.Options;
 
 public class GenerateFileListing : IOption
 {
-    public static readonly string OutputPath     = $"{Path.GetDirectoryName(typeof(TemplateGenerator).Assembly.Location)}/out/GenerateFileListing/Files.md";
+    public static readonly string OutputPath     = $"{AppContext.BaseDirectory}out/GenerateFileListing/Files.md";
     public static readonly string TemplateFolder = $"ListFilesTable";
 
     public string GetName() => "Generate File Listing";

--- a/Source/IndexTool/IndexTool/IndexTool/Options/ListFileTypes.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Options/ListFileTypes.cs
@@ -72,8 +72,15 @@ public class ListFileTypes : IOption
             if (knownType.Extension != null && typesDict.TryGetValue(knownType.Extension, out var type))
             {
                 var origExample = type.Example;
-                knownType.Adapt(type);
-                type.Example = origExample;
+                // Manual copy instead of Mapster Adapt: expression compilation fails under NativeAOT.
+                type.Id                = knownType.Id;
+                type.CustomExtension   = knownType.CustomExtension;
+                type.Format            = knownType.Format;
+                type.Category          = knownType.Category;
+                type.Tools             = knownType.Tools;
+                type.Documentation     = knownType.Documentation;
+                type.Description       = knownType.Description;
+                type.Example           = origExample;
             }
         }
 

--- a/Source/IndexTool/IndexTool/IndexTool/Options/ScanArchiveData.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Options/ScanArchiveData.cs
@@ -16,7 +16,7 @@ namespace IndexTool.Options;
 
 public class ScanArchiveData : IOption
 {
-    public static readonly string OutputPath          = $"{Path.GetDirectoryName(typeof(TemplateGenerator).Assembly.Location)}/out/ScanArchiveData";
+    public static readonly string OutputPath          = $"{AppContext.BaseDirectory}out/ScanArchiveData";
     public static readonly string TemplateTableFolder = $"ListInternalTypesTable";
     public static readonly string TemplateFileFolder  = $"ListInternalTypesFile";
 

--- a/Source/IndexTool/IndexTool/IndexTool/Options/ScanArchiveData.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Options/ScanArchiveData.cs
@@ -119,7 +119,11 @@ public class ScanArchiveData : IOption
         foreach (var knownType in knownTypes)
         {
             if (typesDict.TryGetValue(knownType.Id, out var type))
-                knownType.Adapt(type);
+            {
+                // Manual copy instead of Mapster Adapt: expression compilation fails under NativeAOT.
+                type.Id   = knownType.Id;
+                type.Name = knownType.Name;
+            }
         }
 
         types.Sort((x, y) => x.Id.Value.CompareTo(y.Id.Value));

--- a/Source/IndexTool/IndexTool/IndexTool/Serialization/IndexToolJsonContext.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Serialization/IndexToolJsonContext.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using IndexTool.Structs;
+using Sewer56.SonicRiders.Parser.File.Structures;
+
+namespace IndexTool.Serialization;
+
+/// <summary>Source-gen JSON metadata; reflection serializer fails under NativeAOT.</summary>
+[JsonSourceGenerationOptions(IncludeFields = true, WriteIndented = true)]
+[JsonSerializable(typeof(List<FileTypeEx>))]
+[JsonSerializable(typeof(List<FileType>))]
+[JsonSerializable(typeof(List<InternalFileType>))]
+[JsonSerializable(typeof(List<DataFile>))]
+[JsonSerializable(typeof(FileType))]
+internal partial class IndexToolJsonContext : JsonSerializerContext
+{
+}

--- a/Source/IndexTool/IndexTool/IndexTool/Templates/TemplateGenerator.cs
+++ b/Source/IndexTool/IndexTool/IndexTool/Templates/TemplateGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using IndexTool.Options.Helpers;
 using Scriban;
@@ -23,7 +24,7 @@ public class TemplateGenerator
     /// <param name="directory">Name of the directory inside the `Templates` folder.</param>
     public TemplateGenerator(string directory)
     {
-        Directory = $"{Path.GetDirectoryName(typeof(TemplateGenerator).Assembly.Location)}/Templates/{directory}";
+        Directory = $"{AppContext.BaseDirectory}Templates/{directory}";
     }
 
     /// <summary>

--- a/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/LayoutToJson.csproj
+++ b/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/LayoutToJson.csproj
@@ -2,11 +2,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- NativeAOT; local-only so it never propagates to submodules. -->
+    <PublishAot>true</PublishAot>
+    <!-- JSON reflection serializer; see Serialization/ contexts. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <!-- Trim/AOT warnings persist despite rooting; verified needed. -->
+    <NoWarn>$(NoWarn);IL2026;IL2062;IL2067;IL2075;IL2104;IL3050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <!-- Keep assemblies; used via reflection. -->
+    <TrimmerRootAssembly Include="LayoutToJson" />
+    <TrimmerRootAssembly Include="Sewer56.SonicRiders" />
+    <TrimmerRootAssembly Include="CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Program.cs
+++ b/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Program.cs
@@ -9,6 +9,7 @@ using Reloaded.Memory.Streams;
 using Reloaded.Memory.Streams.Readers;
 using Reloaded.Memory.Streams.Writers;
 using Sewer56.SonicRiders.Parser.Menu.Metadata.Managed;
+using LayoutToJson.Serialization;
 
 namespace LayoutToJson
 {
@@ -16,6 +17,11 @@ namespace LayoutToJson
     {
         static void Main(string[] args)
         {
+            // NativeAOT: source-gen resolver + object values as JsonElement.
+            ManagedMenuMetadata.SerializerOptions.TypeInfoResolver = System.Text.Json.Serialization.Metadata.JsonTypeInfoResolver.Combine(
+                MenuMetadataJsonContext.Default, SystemObjectJsonContext.Default);
+            ManagedMenuMetadata.SerializerOptions.Converters.Add(new ObjectAsJsonElementConverter());
+
             var parser = new Parser(with =>
             {
                 with.AutoHelp = true;

--- a/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Serialization/MenuMetadataJsonContext.cs
+++ b/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Serialization/MenuMetadataJsonContext.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+using Sewer56.SonicRiders.Parser.Menu.Metadata.Managed;
+using ManagedFrames = Sewer56.SonicRiders.Parser.Menu.Metadata.Managed.Frames;
+using MetadataObject = Sewer56.SonicRiders.Parser.Menu.Metadata.Managed.Object;
+using StructFrames = Sewer56.SonicRiders.Parser.Menu.Metadata.Structs.Frames;
+
+namespace LayoutToJson.Serialization;
+
+/// <summary>Source-gen JSON metadata for <see cref="ManagedMenuMetadata"/>; NativeAOT.</summary>
+[JsonSourceGenerationOptions(IncludeFields = true, WriteIndented = true, UseStringEnumConverter = true)]
+[JsonSerializable(typeof(ManagedMenuMetadata))]
+// Registered explicitly: `Object` (Managed.Object) name-collides with System.Object.
+[JsonSerializable(typeof(MetadataObject))]
+[JsonSerializable(typeof(StructFrames.Color))]
+[JsonSerializable(typeof(ManagedFrames.Unknown))]
+internal partial class MenuMetadataJsonContext : JsonSerializerContext
+{
+}

--- a/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Serialization/ObjectAsJsonElementConverter.cs
+++ b/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Serialization/ObjectAsJsonElementConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LayoutToJson.Serialization;
+
+/// <summary>Dictionary object values as JsonElement; converted by Keyframe.Initialize. NativeAOT.</summary>
+public class ObjectAsJsonElementConverter : JsonConverter<object>
+{
+    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        JsonElement.ParseValue(ref reader);
+
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        if (value is JsonElement e)
+            e.WriteTo(writer);
+        else
+            JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Serialization/SystemObjectJsonContext.cs
+++ b/Source/LayoutToJsonTool/LayoutToJson/LayoutToJson/Serialization/SystemObjectJsonContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace LayoutToJson.Serialization;
+
+/// <summary>System.Object in own context; collides with Managed.Object otherwise.</summary>
+[JsonSerializable(typeof(object))]
+internal partial class SystemObjectJsonContext : JsonSerializerContext
+{
+}

--- a/Source/RidersArchiveTool/RidersArchiveTool/RidersArchiveTool.csproj
+++ b/Source/RidersArchiveTool/RidersArchiveTool/RidersArchiveTool.csproj
@@ -2,13 +2,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	  <TargetFramework>net5.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
+	  <!-- NativeAOT; local-only so it never propagates to submodules. -->
+	  <PublishAot>true</PublishAot>
 	  <LangVersion>preview</LangVersion>
 	  <AllowUnsafeCode>true</AllowUnsafeCode>
+	  <!-- Trim/AOT warnings persist despite rooting; verified needed. -->
+	  <NoWarn>$(NoWarn);IL2026;IL2062;IL2067;IL2075;IL2104;IL3050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <!-- Keep assemblies; used via reflection. -->
+    <TrimmerRootAssembly Include="RidersArchiveTool" />
+    <TrimmerRootAssembly Include="Sewer56.SonicRiders" />
+    <TrimmerRootAssembly Include="CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Standart.Hash.xxHash" Version="3.1.0" />
   </ItemGroup>
 

--- a/Source/RidersTextureArchiveTool/RidersTextureArchiveTool/RidersTextureArchiveTool.csproj
+++ b/Source/RidersTextureArchiveTool/RidersTextureArchiveTool/RidersTextureArchiveTool.csproj
@@ -2,13 +2,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	  <TargetFramework>net5.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
+	  <!-- NativeAOT; local-only so it never propagates to submodules. -->
+	  <PublishAot>true</PublishAot>
 	  <LangVersion>preview</LangVersion>
 	  <AllowUnsafeCode>true</AllowUnsafeCode>
+	  <!-- Trim/AOT warnings persist despite rooting; verified needed. -->
+	  <NoWarn>$(NoWarn);IL2026;IL2062;IL2067;IL2075;IL2104;IL3050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <!-- Keep assemblies; used via reflection. -->
+    <TrimmerRootAssembly Include="RidersTextureArchiveTool" />
+    <TrimmerRootAssembly Include="Sewer56.SonicRiders" />
+    <TrimmerRootAssembly Include="CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Publish all 5 tools as NativeAOT binaries for 6 platforms via GitHub Actions. 

- linux-x64
- linux-arm64
- windows-x64
- windows-arm64
- macos-x64
- macos-arm64

## Changes
- Bump tools to `net10.0`.
- Added NativeAOT (`PublishAot`) per-project, never propagating.
- Fixed any trimming/reflection issues.
- IndexTool: Replace Mapster `Adapt()` for NativeAOT.
- NativeAOT: Replace `AppContext.BaseDirectory` for `Assembly.Location`.
- Bump `CommandLineParser` 2.8.0 -> 2.9.1, `Sewer56.SonicRiders` submodule.

## Verification
Tested binaries on real files on NixOS (Linux), both Framework Dependent and NativeAOT
